### PR TITLE
Auto selecting and Gray fields disabling

### DIFF
--- a/dhis-2/dhis-web/dhis-web-apps/src/main/webapp/dhis-web-routine-dataentry/components/dataentry/dataentry-controller.js
+++ b/dhis-2/dhis-web/dhis-web-apps/src/main/webapp/dhis-web-routine-dataentry/components/dataentry/dataentry-controller.js
@@ -158,6 +158,27 @@ routineDataEntry.controller('dataEntryController',
         });
     }
     
+    $scope.checkDisabled = function (section,de,oco){
+        if($scope.model && $scope.model.dataSetCompletness && $scope.model.dataSetCompletness[$scope.model.selectedAttributeOptionCombo]){//if dataset is complete return true (disabled) without checking anything.
+            return true;
+        }
+        else if(de.controlling_data_element){//if data element is a controlling data element return false (is not disabled)
+                                        //it is only disabled when the dataSet is marked complete.
+            return false;
+        }
+        
+        else if(section.greyedFields.indexOf(de.id+'.'+oco.id) !== -1){//if the category option combo is greyed out return true;
+            return true;
+        }
+        else if($scope.controllingDataElementGroups[$scope.groupsByMember[de.id]] && $scope.controllingDataElementGroups[$scope.groupsByMember[de.id]].isDisabled){
+            //return if controlling data element value is disabled.
+            return true;
+        }
+        //if the above conditions are not fullfilled return false;
+        return false;
+        //return (section.greyedFields.indexOf(de.id+'.'+oco.id) !== -1 || $scope.controllingDataElementGroups[$scope.groupsByMember[de.id]].isDisabled) && !de.controlling_data_element || $scope.model.dataSetCompletness[$scope.model.selectedAttributeOptionCombo];
+    }
+    
     $scope.performAutoZero = function(section){
         var dataValueSet = {
             dataSet: $scope.model.selectedDataSet.id,
@@ -171,6 +192,9 @@ routineDataEntry.controller('dataEntryController',
             dataElement = $scope.model.dataElements[dataElement.id];
             if (dataElement && (dataElement.valueType === 'NUMBER' || dataElement.valueType === "INTEGER" || dataElement.valueType === "INTEGER_ZERO_OR_POSITIVE")) {
                 angular.forEach($scope.model.categoryCombos[dataElement.categoryCombo.id].categoryOptionCombos, function (categoryOptionCombo) {
+                    if($scope.checkDisabled(section,dataElement,categoryOptionCombo)){
+                        return;
+                    }
                     //check if the data value of the data element has a catagoroptiondownloaded
                     if (!$scope.dataValues[dataElement.id]) {
                         $scope.dataValues[dataElement.id] = {};

--- a/dhis-2/dhis-web/dhis-web-apps/src/main/webapp/dhis-web-routine-dataentry/components/dataentry/default-form.html
+++ b/dhis-2/dhis-web/dhis-web-apps/src/main/webapp/dhis-web-routine-dataentry/components/dataentry/default-form.html
@@ -80,7 +80,7 @@
                                             <span ng-if="de.optionSetValue">
                                                 <ui-select theme="select2" 
                                                            ng-model="dataValues[de.id][oco.id].value" 
-                                                           ng-disabled="(section.greyedFields.indexOf(de.id+'.'+oco.id) !== -1 || controllingDataElementGroups[groupsByMember[de.id]].isDisabled) && !de.controlling_data_element || model.dataSetCompletness[model.selectedAttributeOptionCombo]" 
+                                                           ng-disabled="checkDisabled(section,de,oco);" 
                                                            d2-tab-index 
                                                            tabindex={{tabOrder[de.id][oco.id]}}
                                                            name="foo" 
@@ -104,7 +104,7 @@
                                                         <textarea rows="5" 
                                                                   name="foo"                                                          
                                                                   ng-model="dataValues[de.id][oco.id].value" 
-                                                                  ng-disabled="(section.greyedFields.indexOf(de.id+'.'+oco.id) !== -1 || controllingDataElementGroups[groupsByMember[de.id]].isDisabled) && !de.controlling_data_element || model.dataSetCompletness[model.selectedAttributeOptionCombo]"
+                                                                  ng-disabled="checkDisabled(section,de,oco);"
                                                                   d2-tab-index
                                                                   tabindex={{tabOrder[de.id][oco.id]}}
                                                                   class="form-control" 
@@ -116,7 +116,7 @@
                                                         <input type="text" 
                                                                name="foo"
                                                                ng-model="dataValues[de.id][oco.id].value" 
-                                                               ng-disabled="(section.greyedFields.indexOf(de.id+'.'+oco.id) !== -1 || controllingDataElementGroups[groupsByMember[de.id]].isDisabled) && !de.controlling_data_element || model.dataSetCompletness[model.selectedAttributeOptionCombo]"
+                                                               ng-disabled="checkDisabled(section,de,oco);"
                                                                d2-tab-index
                                                                tabindex={{tabOrder[de.id][oco.id]}}
                                                                class="form-control" 
@@ -129,7 +129,7 @@
                                                                d2-number-validator
                                                                number-type={{de.valueType}}
                                                                ng-model="dataValues[de.id][oco.id].value" 
-                                                               ng-disabled="(section.greyedFields.indexOf(de.id+'.'+oco.id) !== -1 || controllingDataElementGroups[groupsByMember[de.id]].isDisabled) && !de.controlling_data_element || model.dataSetCompletness[model.selectedAttributeOptionCombo]"
+                                                               ng-disabled="checkDisabled(section,de,oco);"
                                                                d2-tab-index
                                                                tabindex={{tabOrder[de.id][oco.id]}}
                                                                class="form-control" 
@@ -143,7 +143,7 @@
                                                                d2-number-validator
                                                                number-type={{de.valueType}}
                                                                ng-model="dataValues[de.id][oco.id].value" 
-                                                               ng-disabled="(section.greyedFields.indexOf(de.id+'.'+oco.id) !== -1 || controllingDataElementGroups[groupsByMember[de.id]].isDisabled) && !de.controlling_data_element || model.dataSetCompletness[model.selectedAttributeOptionCombo]"
+                                                               ng-disabled="checkDisabled(section,de,oco);"
                                                                d2-tab-index
                                                                tabindex={{tabOrder[de.id][oco.id]}}
                                                                class="form-control" 
@@ -157,7 +157,7 @@
                                                                d2-number-validator
                                                                number-type={{de.valueType}}
                                                                ng-model="dataValues[de.id][oco.id].value" 
-                                                               ng-disabled="(section.greyedFields.indexOf(de.id+'.'+oco.id) !== -1 || controllingDataElementGroups[groupsByMember[de.id]].isDisabled) && !de.controlling_data_element || model.dataSetCompletness[model.selectedAttributeOptionCombo]"
+                                                               ng-disabled="checkDisabled(section,de,oco);"
                                                                d2-tab-index
                                                                tabindex={{tabOrder[de.id][oco.id]}}
                                                                class="form-control" 
@@ -171,7 +171,7 @@
                                                                d2-number-validator
                                                                number-type={{de.valueType}}
                                                                ng-model="dataValues[de.id][oco.id].value" 
-                                                               ng-disabled="(section.greyedFields.indexOf(de.id+'.'+oco.id) !== -1 || controllingDataElementGroups[groupsByMember[de.id]].isDisabled) && !de.controlling_data_element || model.dataSetCompletness[model.selectedAttributeOptionCombo]"
+                                                               ng-disabled="checkDisabled(section,de,oco);"
                                                                d2-tab-index
                                                                tabindex={{tabOrder[de.id][oco.id]}}
                                                                class="form-control" 
@@ -185,7 +185,7 @@
                                                                d2-number-validator
                                                                number-type={{de.valueType}}
                                                                ng-model="dataValues[de.id][oco.id].value" 
-                                                               ng-disabled="(section.greyedFields.indexOf(de.id+'.'+oco.id) !== -1 || controllingDataElementGroups[groupsByMember[de.id]].isDisabled) && !de.controlling_data_element || model.dataSetCompletness[model.selectedAttributeOptionCombo]"
+                                                               ng-disabled="checkDisabled(section,de,oco);"
                                                                d2-tab-index
                                                                tabindex={{tabOrder[de.id][oco.id]}}
                                                                class="form-control" 
@@ -197,7 +197,7 @@
                                                         <input type="checkbox"   
                                                                name="foo"
                                                                ng-model="dataValues[de.id][oco.id].value" 
-                                                               ng-disabled="(section.greyedFields.indexOf(de.id+'.'+oco.id) !== -1 || controllingDataElementGroups[groupsByMember[de.id]].isDisabled) && !de.controlling_data_element || model.dataSetCompletness[model.selectedAttributeOptionCombo]"
+                                                               ng-disabled="checkDisabled(section,de,oco);"
                                                                d2-tab-index
                                                                tabindex={{tabOrder[de.id][oco.id]}}
                                                                class="form-control" 
@@ -210,7 +210,7 @@
                                                                d2-number-validator
                                                                number-type={{de.valueType}}
                                                                ng-model="dataValues[de.id][oco.id].value" 
-                                                               ng-disabled="(section.greyedFields.indexOf(de.id+'.'+oco.id) !== -1 || controllingDataElementGroups[groupsByMember[de.id]].isDisabled) && !de.controlling_data_element || model.dataSetCompletness[model.selectedAttributeOptionCombo]"
+                                                               ng-disabled="checkDisabled(section,de,oco);"
                                                                d2-tab-index
                                                                tabindex={{tabOrder[de.id][oco.id]}}
                                                                class="form-control" 
@@ -221,7 +221,7 @@
                                                     <span ng-switch-when="BOOLEAN">                                                    
                                                         <ui-select theme="select2" 
                                                                    ng-model="dataValues[de.id][oco.id].value" 
-                                                                   ng-disabled="(section.greyedFields.indexOf(de.id+'.'+oco.id) !== -1 || controllingDataElementGroups[groupsByMember[de.id]].isDisabled) && !de.controlling_data_element || model.dataSetCompletness[model.selectedAttributeOptionCombo]" 
+                                                                   ng-disabled="checkDisabled(section,de,oco);"
                                                                    d2-tab-index
                                                                    tabindex={{tabOrder[de.id][oco.id]}}
                                                                    name="foo"                                                                  
@@ -328,7 +328,7 @@
                             <span ng-if="de.optionSetValue">
                                 <ui-select theme="select2" 
                                            ng-model="dataValues[de.id][oco.id].value" 
-                                           ng-disabled="controllingDataElementGroups[groupsByMember[de.id]].isDisabled && !de.controlling_data_element || model.dataSetCompletness[model.selectedAttributeOptionCombo]" 
+                                           ng-disabled="checkDisabled(section,de,oco);"
                                            name="foo" 
                                            d2-tab-index
                                            tabindex={{tabOrder[de.id][oco.id]}}
@@ -352,7 +352,7 @@
                                         <textarea rows="5" 
                                                   name="foo"                                                          
                                                   ng-model="dataValues[de.id][oco.id].value" 
-                                                  d2-disabled="controllingDataElementGroups[groupsByMember[de.id]].isDisabled && !de.controlling_data_element || model.dataSetCompletness[model.selectedAttributeOptionCombo]"
+                                                  d2-disabled="checkDisabled(section,de,oco);"
                                                   d2-tab-index
                                                   tabindex={{tabOrder[de.id][oco.id]}}
                                                   class="form-control" 
@@ -364,7 +364,7 @@
                                         <input type="text" 
                                                name="foo"
                                                ng-model="dataValues[de.id][oco.id].value" 
-                                               d2-disabled="controllingDataElementGroups[groupsByMember[de.id]].isDisabled && !de.controlling_data_element || model.dataSetCompletness[model.selectedAttributeOptionCombo]"
+                                               d2-disabled="checkDisabled(section,de,oco);"
                                                d2-tab-index
                                                tabindex={{tabOrder[de.id][oco.id]}}
                                                class="form-control" 
@@ -377,7 +377,7 @@
                                                d2-number-validator
                                                number-type={{de.valueType}}
                                                ng-model="dataValues[de.id][oco.id].value" 
-                                               d2-disabled="controllingDataElementGroups[groupsByMember[de.id]].isDisabled && !de.controlling_data_element || model.dataSetCompletness[model.selectedAttributeOptionCombo]"
+                                               d2-disabled="checkDisabled(section,de,oco);"
                                                d2-tab-index
                                                tabindex={{tabOrder[de.id][oco.id]}}
                                                class="form-control" 
@@ -391,7 +391,7 @@
                                                d2-number-validator
                                                number-type={{de.valueType}}
                                                ng-model="dataValues[de.id][oco.id].value" 
-                                               d2-disabled="controllingDataElementGroups[groupsByMember[de.id]].isDisabled && !de.controlling_data_element || model.dataSetCompletness[model.selectedAttributeOptionCombo]"
+                                               d2-disabled="checkDisabled(section,de,oco);"
                                                d2-tab-index
                                                tabindex={{tabOrder[de.id][oco.id]}}
                                                class="form-control" 
@@ -405,7 +405,7 @@
                                                d2-number-validator
                                                number-type={{de.valueType}}
                                                ng-model="dataValues[de.id][oco.id].value" 
-                                               d2-disabled="controllingDataElementGroups[groupsByMember[de.id]].isDisabled && !de.controlling_data_element || model.dataSetCompletness[model.selectedAttributeOptionCombo]"
+                                               d2-disabled="checkDisabled(section,de,oco);"
                                                d2-tab-index
                                                tabindex={{tabOrder[de.id][oco.id]}}
                                                class="form-control" 
@@ -419,7 +419,7 @@
                                                d2-number-validator
                                                number-type={{de.valueType}}
                                                ng-model="dataValues[de.id][oco.id].value" 
-                                               d2-disabled="controllingDataElementGroups[groupsByMember[de.id]].isDisabled && !de.controlling_data_element || model.dataSetCompletness[model.selectedAttributeOptionCombo]"
+                                               d2-disabled="checkDisabled(section,de,oco);"
                                                d2-tab-index
                                                tabindex={{tabOrder[de.id][oco.id]}}
                                                class="form-control" 
@@ -433,7 +433,7 @@
                                                d2-number-validator
                                                number-type={{de.valueType}}
                                                ng-model="dataValues[de.id][oco.id].value" 
-                                               d2-disabled="controllingDataElementGroups[groupsByMember[de.id]].isDisabled && !de.controlling_data_element || model.dataSetCompletness[model.selectedAttributeOptionCombo]"
+                                               d2-disabled="checkDisabled(section,de,oco);"
                                                d2-tab-index
                                                tabindex={{tabOrder[de.id][oco.id]}}
                                                class="form-control" 
@@ -445,7 +445,7 @@
                                         <input type="checkbox"   
                                                name="foo"
                                                ng-model="dataValues[de.id][oco.id].value" 
-                                               d2-disabled="controllingDataElementGroups[groupsByMember[de.id]].isDisabled && !de.controlling_data_element || model.dataSetCompletness[model.selectedAttributeOptionCombo]"
+                                               d2-disabled="checkDisabled(section,de,oco);"
                                                d2-tab-index
                                                tabindex={{tabOrder[de.id][oco.id]}}
                                                class="form-control" 
@@ -458,7 +458,7 @@
                                                d2-number-validator
                                                number-type={{de.valueType}}
                                                ng-model="dataValues[de.id][oco.id].value" 
-                                               ng-disabled="(section.greyedFields.indexOf(de.id+'.'+oco.id) !== -1 || controllingDataElementGroups[groupsByMember[de.id]].isDisabled) && !de.controlling_data_element || model.dataSetCompletness[model.selectedAttributeOptionCombo]"
+                                               ng-disabled="checkDisabled(section,de,oco);"
                                                d2-tab-index
                                                tabindex={{tabOrder[de.id][oco.id]}}
                                                class="form-control" 
@@ -469,7 +469,7 @@
                                     <span ng-switch-when="BOOLEAN">                                                    
                                         <ui-select theme="select2" 
                                                    ng-model="dataValues[de.id][oco.id].value" 
-                                                   ng-disabled="controllingDataElementGroups[groupsByMember[de.id]].isDisabled && !de.controlling_data_element || || model.dataSetCompletness[model.selectedAttributeOptionCombo]" 
+                                                   ng-disabled="checkDisabled(section,de,oco);"
                                                    name="foo"   
                                                    d2-tab-index
                                                    tabindex={{tabOrder[de.id][oco.id]}}

--- a/dhis-2/dhis-web/dhis-web-apps/src/main/webapp/dhis-web-routine-dataentry/components/dataentry/default-form.html
+++ b/dhis-2/dhis-web/dhis-web-apps/src/main/webapp/dhis-web-routine-dataentry/components/dataentry/default-form.html
@@ -80,7 +80,7 @@
                                             <span ng-if="de.optionSetValue">
                                                 <ui-select theme="select2" 
                                                            ng-model="dataValues[de.id][oco.id].value" 
-                                                           ng-disabled="(section.greyedFields.indexOf(de.id+'.'+oco.id) !== -1 || controllingDataElementGroups[groupsByMember[de.id]].isDisabled) && !de.controlling_data_element" 
+                                                           ng-disabled="(section.greyedFields.indexOf(de.id+'.'+oco.id) !== -1 || controllingDataElementGroups[groupsByMember[de.id]].isDisabled) && !de.controlling_data_element || model.dataSetCompletness[model.selectedAttributeOptionCombo]" 
                                                            d2-tab-index 
                                                            tabindex={{tabOrder[de.id][oco.id]}}
                                                            name="foo" 
@@ -104,7 +104,7 @@
                                                         <textarea rows="5" 
                                                                   name="foo"                                                          
                                                                   ng-model="dataValues[de.id][oco.id].value" 
-                                                                  ng-disabled="(section.greyedFields.indexOf(de.id+'.'+oco.id) !== -1 || controllingDataElementGroups[groupsByMember[de.id]].isDisabled) && !de.controlling_data_element"
+                                                                  ng-disabled="(section.greyedFields.indexOf(de.id+'.'+oco.id) !== -1 || controllingDataElementGroups[groupsByMember[de.id]].isDisabled) && !de.controlling_data_element || model.dataSetCompletness[model.selectedAttributeOptionCombo]"
                                                                   d2-tab-index
                                                                   tabindex={{tabOrder[de.id][oco.id]}}
                                                                   class="form-control" 
@@ -116,7 +116,7 @@
                                                         <input type="text" 
                                                                name="foo"
                                                                ng-model="dataValues[de.id][oco.id].value" 
-                                                               ng-disabled="(section.greyedFields.indexOf(de.id+'.'+oco.id) !== -1 || controllingDataElementGroups[groupsByMember[de.id]].isDisabled) && !de.controlling_data_element"
+                                                               ng-disabled="(section.greyedFields.indexOf(de.id+'.'+oco.id) !== -1 || controllingDataElementGroups[groupsByMember[de.id]].isDisabled) && !de.controlling_data_element || model.dataSetCompletness[model.selectedAttributeOptionCombo]"
                                                                d2-tab-index
                                                                tabindex={{tabOrder[de.id][oco.id]}}
                                                                class="form-control" 
@@ -129,7 +129,7 @@
                                                                d2-number-validator
                                                                number-type={{de.valueType}}
                                                                ng-model="dataValues[de.id][oco.id].value" 
-                                                               ng-disabled="(section.greyedFields.indexOf(de.id+'.'+oco.id) !== -1 || controllingDataElementGroups[groupsByMember[de.id]].isDisabled) && !de.controlling_data_element"
+                                                               ng-disabled="(section.greyedFields.indexOf(de.id+'.'+oco.id) !== -1 || controllingDataElementGroups[groupsByMember[de.id]].isDisabled) && !de.controlling_data_element || model.dataSetCompletness[model.selectedAttributeOptionCombo]"
                                                                d2-tab-index
                                                                tabindex={{tabOrder[de.id][oco.id]}}
                                                                class="form-control" 
@@ -143,7 +143,7 @@
                                                                d2-number-validator
                                                                number-type={{de.valueType}}
                                                                ng-model="dataValues[de.id][oco.id].value" 
-                                                               ng-disabled="(section.greyedFields.indexOf(de.id+'.'+oco.id) !== -1 || controllingDataElementGroups[groupsByMember[de.id]].isDisabled) && !de.controlling_data_element"
+                                                               ng-disabled="(section.greyedFields.indexOf(de.id+'.'+oco.id) !== -1 || controllingDataElementGroups[groupsByMember[de.id]].isDisabled) && !de.controlling_data_element || model.dataSetCompletness[model.selectedAttributeOptionCombo]"
                                                                d2-tab-index
                                                                tabindex={{tabOrder[de.id][oco.id]}}
                                                                class="form-control" 
@@ -157,7 +157,7 @@
                                                                d2-number-validator
                                                                number-type={{de.valueType}}
                                                                ng-model="dataValues[de.id][oco.id].value" 
-                                                               ng-disabled="(section.greyedFields.indexOf(de.id+'.'+oco.id) !== -1 || controllingDataElementGroups[groupsByMember[de.id]].isDisabled) && !de.controlling_data_element"
+                                                               ng-disabled="(section.greyedFields.indexOf(de.id+'.'+oco.id) !== -1 || controllingDataElementGroups[groupsByMember[de.id]].isDisabled) && !de.controlling_data_element || model.dataSetCompletness[model.selectedAttributeOptionCombo]"
                                                                d2-tab-index
                                                                tabindex={{tabOrder[de.id][oco.id]}}
                                                                class="form-control" 
@@ -171,7 +171,7 @@
                                                                d2-number-validator
                                                                number-type={{de.valueType}}
                                                                ng-model="dataValues[de.id][oco.id].value" 
-                                                               ng-disabled="(section.greyedFields.indexOf(de.id+'.'+oco.id) !== -1 || controllingDataElementGroups[groupsByMember[de.id]].isDisabled) && !de.controlling_data_element"
+                                                               ng-disabled="(section.greyedFields.indexOf(de.id+'.'+oco.id) !== -1 || controllingDataElementGroups[groupsByMember[de.id]].isDisabled) && !de.controlling_data_element || model.dataSetCompletness[model.selectedAttributeOptionCombo]"
                                                                d2-tab-index
                                                                tabindex={{tabOrder[de.id][oco.id]}}
                                                                class="form-control" 
@@ -185,7 +185,7 @@
                                                                d2-number-validator
                                                                number-type={{de.valueType}}
                                                                ng-model="dataValues[de.id][oco.id].value" 
-                                                               ng-disabled="(section.greyedFields.indexOf(de.id+'.'+oco.id) !== -1 || controllingDataElementGroups[groupsByMember[de.id]].isDisabled) && !de.controlling_data_element"
+                                                               ng-disabled="(section.greyedFields.indexOf(de.id+'.'+oco.id) !== -1 || controllingDataElementGroups[groupsByMember[de.id]].isDisabled) && !de.controlling_data_element || model.dataSetCompletness[model.selectedAttributeOptionCombo]"
                                                                d2-tab-index
                                                                tabindex={{tabOrder[de.id][oco.id]}}
                                                                class="form-control" 
@@ -197,7 +197,7 @@
                                                         <input type="checkbox"   
                                                                name="foo"
                                                                ng-model="dataValues[de.id][oco.id].value" 
-                                                               ng-disabled="(section.greyedFields.indexOf(de.id+'.'+oco.id) !== -1 || controllingDataElementGroups[groupsByMember[de.id]].isDisabled) && !de.controlling_data_element"
+                                                               ng-disabled="(section.greyedFields.indexOf(de.id+'.'+oco.id) !== -1 || controllingDataElementGroups[groupsByMember[de.id]].isDisabled) && !de.controlling_data_element || model.dataSetCompletness[model.selectedAttributeOptionCombo]"
                                                                d2-tab-index
                                                                tabindex={{tabOrder[de.id][oco.id]}}
                                                                class="form-control" 
@@ -210,7 +210,7 @@
                                                                d2-number-validator
                                                                number-type={{de.valueType}}
                                                                ng-model="dataValues[de.id][oco.id].value" 
-                                                               ng-disabled="(section.greyedFields.indexOf(de.id+'.'+oco.id) !== -1 || controllingDataElementGroups[groupsByMember[de.id]].isDisabled) && !de.controlling_data_element"
+                                                               ng-disabled="(section.greyedFields.indexOf(de.id+'.'+oco.id) !== -1 || controllingDataElementGroups[groupsByMember[de.id]].isDisabled) && !de.controlling_data_element || model.dataSetCompletness[model.selectedAttributeOptionCombo]"
                                                                d2-tab-index
                                                                tabindex={{tabOrder[de.id][oco.id]}}
                                                                class="form-control" 
@@ -221,7 +221,7 @@
                                                     <span ng-switch-when="BOOLEAN">                                                    
                                                         <ui-select theme="select2" 
                                                                    ng-model="dataValues[de.id][oco.id].value" 
-                                                                   ng-disabled="(section.greyedFields.indexOf(de.id+'.'+oco.id) !== -1 || controllingDataElementGroups[groupsByMember[de.id]].isDisabled) && !de.controlling_data_element" 
+                                                                   ng-disabled="(section.greyedFields.indexOf(de.id+'.'+oco.id) !== -1 || controllingDataElementGroups[groupsByMember[de.id]].isDisabled) && !de.controlling_data_element || model.dataSetCompletness[model.selectedAttributeOptionCombo]" 
                                                                    d2-tab-index
                                                                    tabindex={{tabOrder[de.id][oco.id]}}
                                                                    name="foo"                                                                  
@@ -328,7 +328,7 @@
                             <span ng-if="de.optionSetValue">
                                 <ui-select theme="select2" 
                                            ng-model="dataValues[de.id][oco.id].value" 
-                                           ng-disabled="controllingDataElementGroups[groupsByMember[de.id]].isDisabled && !de.controlling_data_element" 
+                                           ng-disabled="controllingDataElementGroups[groupsByMember[de.id]].isDisabled && !de.controlling_data_element || model.dataSetCompletness[model.selectedAttributeOptionCombo]" 
                                            name="foo" 
                                            d2-tab-index
                                            tabindex={{tabOrder[de.id][oco.id]}}
@@ -352,7 +352,7 @@
                                         <textarea rows="5" 
                                                   name="foo"                                                          
                                                   ng-model="dataValues[de.id][oco.id].value" 
-                                                  d2-disabled="controllingDataElementGroups[groupsByMember[de.id]].isDisabled && !de.controlling_data_element"
+                                                  d2-disabled="controllingDataElementGroups[groupsByMember[de.id]].isDisabled && !de.controlling_data_element || model.dataSetCompletness[model.selectedAttributeOptionCombo]"
                                                   d2-tab-index
                                                   tabindex={{tabOrder[de.id][oco.id]}}
                                                   class="form-control" 
@@ -364,7 +364,7 @@
                                         <input type="text" 
                                                name="foo"
                                                ng-model="dataValues[de.id][oco.id].value" 
-                                               d2-disabled="controllingDataElementGroups[groupsByMember[de.id]].isDisabled && !de.controlling_data_element"
+                                               d2-disabled="controllingDataElementGroups[groupsByMember[de.id]].isDisabled && !de.controlling_data_element || model.dataSetCompletness[model.selectedAttributeOptionCombo]"
                                                d2-tab-index
                                                tabindex={{tabOrder[de.id][oco.id]}}
                                                class="form-control" 
@@ -377,7 +377,7 @@
                                                d2-number-validator
                                                number-type={{de.valueType}}
                                                ng-model="dataValues[de.id][oco.id].value" 
-                                               d2-disabled="controllingDataElementGroups[groupsByMember[de.id]].isDisabled && !de.controlling_data_element"
+                                               d2-disabled="controllingDataElementGroups[groupsByMember[de.id]].isDisabled && !de.controlling_data_element || model.dataSetCompletness[model.selectedAttributeOptionCombo]"
                                                d2-tab-index
                                                tabindex={{tabOrder[de.id][oco.id]}}
                                                class="form-control" 
@@ -391,7 +391,7 @@
                                                d2-number-validator
                                                number-type={{de.valueType}}
                                                ng-model="dataValues[de.id][oco.id].value" 
-                                               d2-disabled="controllingDataElementGroups[groupsByMember[de.id]].isDisabled && !de.controlling_data_element"
+                                               d2-disabled="controllingDataElementGroups[groupsByMember[de.id]].isDisabled && !de.controlling_data_element || model.dataSetCompletness[model.selectedAttributeOptionCombo]"
                                                d2-tab-index
                                                tabindex={{tabOrder[de.id][oco.id]}}
                                                class="form-control" 
@@ -405,7 +405,7 @@
                                                d2-number-validator
                                                number-type={{de.valueType}}
                                                ng-model="dataValues[de.id][oco.id].value" 
-                                               d2-disabled="controllingDataElementGroups[groupsByMember[de.id]].isDisabled && !de.controlling_data_element"
+                                               d2-disabled="controllingDataElementGroups[groupsByMember[de.id]].isDisabled && !de.controlling_data_element || model.dataSetCompletness[model.selectedAttributeOptionCombo]"
                                                d2-tab-index
                                                tabindex={{tabOrder[de.id][oco.id]}}
                                                class="form-control" 
@@ -419,7 +419,7 @@
                                                d2-number-validator
                                                number-type={{de.valueType}}
                                                ng-model="dataValues[de.id][oco.id].value" 
-                                               d2-disabled="controllingDataElementGroups[groupsByMember[de.id]].isDisabled && !de.controlling_data_element"
+                                               d2-disabled="controllingDataElementGroups[groupsByMember[de.id]].isDisabled && !de.controlling_data_element || model.dataSetCompletness[model.selectedAttributeOptionCombo]"
                                                d2-tab-index
                                                tabindex={{tabOrder[de.id][oco.id]}}
                                                class="form-control" 
@@ -433,7 +433,7 @@
                                                d2-number-validator
                                                number-type={{de.valueType}}
                                                ng-model="dataValues[de.id][oco.id].value" 
-                                               d2-disabled="controllingDataElementGroups[groupsByMember[de.id]].isDisabled && !de.controlling_data_element"
+                                               d2-disabled="controllingDataElementGroups[groupsByMember[de.id]].isDisabled && !de.controlling_data_element || model.dataSetCompletness[model.selectedAttributeOptionCombo]"
                                                d2-tab-index
                                                tabindex={{tabOrder[de.id][oco.id]}}
                                                class="form-control" 
@@ -445,7 +445,7 @@
                                         <input type="checkbox"   
                                                name="foo"
                                                ng-model="dataValues[de.id][oco.id].value" 
-                                               d2-disabled="controllingDataElementGroups[groupsByMember[de.id]].isDisabled && !de.controlling_data_element"
+                                               d2-disabled="controllingDataElementGroups[groupsByMember[de.id]].isDisabled && !de.controlling_data_element || model.dataSetCompletness[model.selectedAttributeOptionCombo]"
                                                d2-tab-index
                                                tabindex={{tabOrder[de.id][oco.id]}}
                                                class="form-control" 
@@ -458,7 +458,7 @@
                                                d2-number-validator
                                                number-type={{de.valueType}}
                                                ng-model="dataValues[de.id][oco.id].value" 
-                                               ng-disabled="(section.greyedFields.indexOf(de.id+'.'+oco.id) !== -1 || controllingDataElementGroups[groupsByMember[de.id]].isDisabled) && !de.controlling_data_element"
+                                               ng-disabled="(section.greyedFields.indexOf(de.id+'.'+oco.id) !== -1 || controllingDataElementGroups[groupsByMember[de.id]].isDisabled) && !de.controlling_data_element || model.dataSetCompletness[model.selectedAttributeOptionCombo]"
                                                d2-tab-index
                                                tabindex={{tabOrder[de.id][oco.id]}}
                                                class="form-control" 
@@ -469,7 +469,7 @@
                                     <span ng-switch-when="BOOLEAN">                                                    
                                         <ui-select theme="select2" 
                                                    ng-model="dataValues[de.id][oco.id].value" 
-                                                   ng-disabled="controllingDataElementGroups[groupsByMember[de.id]].isDisabled && !de.controlling_data_element" 
+                                                   ng-disabled="controllingDataElementGroups[groupsByMember[de.id]].isDisabled && !de.controlling_data_element || || model.dataSetCompletness[model.selectedAttributeOptionCombo]" 
                                                    name="foo"   
                                                    d2-tab-index
                                                    tabindex={{tabOrder[de.id][oco.id]}}

--- a/dhis-2/dhis-web/dhis-web-apps/src/main/webapp/dhis-web-routine-dataentry/scripts/routine-dataentry.js
+++ b/dhis-2/dhis-web/dhis-web-apps/src/main/webapp/dhis-web-routine-dataentry/scripts/routine-dataentry.js
@@ -242,7 +242,7 @@ function filterMissingDataSets( objs ){
 }
 
 function getDataSets( ids ){
-    return dhis2.metadata.getBatches( ids, batchSize, 'dataSets', 'dataSets', '../api/dataSets.json', 'paging=false&fields=id,periodType,openFuturePeriods,displayName,version,categoryCombo[id],attributeValues[value,attribute[id,name,valueType,code]],organisationUnits[id],sections[id,displayName,sortOrder,code,dataElements,greyedFields[dimensionItem],indicators[displayName,indicatorType,numerator,denominator,attributeValues[value,attribute[id,name,valueType,code]]]],dataSetElements[id,dataElement[id,code,displayFormName,description,optionSetValue,optionSet[id],attributeValues[value,attribute[id,name,valueType,code]],description,formName,valueType,optionSetValue,optionSet[id],categoryCombo[id]]]', 'idb', dhis2.routineDataEntry.store, dhis2.metadata.processObject);
+    return dhis2.metadata.getBatches( ids, batchSize, 'dataSets', 'dataSets', '../api/dataSets.json', 'paging=false&fields=id,periodType,openFuturePeriods,displayName,version,categoryCombo[id],attributeValues[value,attribute[id,name,valueType,code]],organisationUnits[id],sections[id,displayName,description,sortOrder,code,dataElements,greyedFields[dimensionItem],indicators[displayName,indicatorType,numerator,denominator,attributeValues[value,attribute[id,name,valueType,code]]]],dataSetElements[id,dataElement[id,code,displayFormName,description,optionSetValue,optionSet[id],attributeValues[value,attribute[id,name,valueType,code]],description,formName,valueType,optionSetValue,optionSet[id],categoryCombo[id]]]', 'idb', dhis2.routineDataEntry.store, dhis2.metadata.processObject);
 }
 
 function getMetaOptionSets(){

--- a/dhis-2/dhis-web/dhis-web-commons-resources/src/main/webapp/dhis-web-commons/javascripts/dhis2/dhis2.angular.directives.js
+++ b/dhis-2/dhis-web/dhis-web-commons-resources/src/main/webapp/dhis-web-commons/javascripts/dhis2/dhis2.angular.directives.js
@@ -755,6 +755,12 @@ var d2Directives = angular.module('d2Directives', [])
     return{
         restrict: 'A',
         link: function (scope, element, attrs) {
+            
+            element.bind("onclick", function(event){
+                if(this.type==="number"){
+                    this.select();
+                }
+            });
                 
             element.bind("keydown keypress", function (event) {                
                 
@@ -783,16 +789,13 @@ var d2Directives = angular.module('d2Directives', [])
                     
                     if( field ){                    
                         field.focus();
-                        if(field[0]){ //added to support drop downs and other select html tags. 
-                            var tempType=field[0].type;//need to change type temporarly to text because HTML5 doesn't allow setSelectionRange on number and some other inputs.
-                            field[0].type="text";
-                            field[0].setSelectionRange(0,field[0].value.length);
-                            field[0].type=tempType;
+                        if(field[0]){ 
+                            field[0].select();
                         }
                     }
                 }                
                 else if( ( key === 9 && !event.shiftKey ) || key === 13 || key === 39 || key === 40 ){//get next input field
-                    
+                        
                 	event.preventDefault(); 
                     event.stopPropagation();
                     
@@ -810,10 +813,7 @@ var d2Directives = angular.module('d2Directives', [])
                     if( field ){                    
                         field.focus();
                         if(field[0]){
-                            var tempType=field[0].type;//need to change type temporarly to text because HTML5 doesn't allow setSelectionRange on number and some other inputs.
-                            field[0].type="text";
-                            field[0].setSelectionRange(0,field[0].value.length);
-                            field[0].type=tempType;
+                            field[0].select();
                         }
                     }                   
                 }

--- a/dhis-2/dhis-web/dhis-web-commons-resources/src/main/webapp/dhis-web-commons/javascripts/dhis2/dhis2.angular.directives.js
+++ b/dhis-2/dhis-web/dhis-web-commons-resources/src/main/webapp/dhis-web-commons/javascripts/dhis2/dhis2.angular.directives.js
@@ -1,4 +1,4 @@
-/* global moment, angular, directive, dhis2, selection */
++/* global moment, angular, directive, dhis2, selection */
 
 'use strict';
 
@@ -783,10 +783,12 @@ var d2Directives = angular.module('d2Directives', [])
                     
                     if( field ){                    
                         field.focus();
-                        var tempType=field[0].type;//need to change type temporarly to text because HTML5 doesn't allow setSelectionRange on number and some other inputs.
-                        field[0].type="text";
-                        field[0].setSelectionRange(0,field[0].value.length);
-                        field[0].type=tempType;
+                        if(field[0]){ //added to support drop downs and other select html tags. 
+                            var tempType=field[0].type;//need to change type temporarly to text because HTML5 doesn't allow setSelectionRange on number and some other inputs.
+                            field[0].type="text";
+                            field[0].setSelectionRange(0,field[0].value.length);
+                            field[0].type=tempType;
+                        }
                     }
                 }                
                 else if( ( key === 9 && !event.shiftKey ) || key === 13 || key === 39 || key === 40 ){//get next input field
@@ -807,10 +809,12 @@ var d2Directives = angular.module('d2Directives', [])
                     
                     if( field ){                    
                         field.focus();
-                        var tempType=field[0].type;//need to change type temporarly to text because HTML5 doesn't allow setSelectionRange on number and some other inputs.
-                        field[0].type="text";
-                        field[0].setSelectionRange(0,field[0].value.length);
-                        field[0].type=tempType;
+                        if(field[0]){
+                            var tempType=field[0].type;//need to change type temporarly to text because HTML5 doesn't allow setSelectionRange on number and some other inputs.
+                            field[0].type="text";
+                            field[0].setSelectionRange(0,field[0].value.length);
+                            field[0].type=tempType;
+                        }
                     }                   
                 }
             });

--- a/dhis-2/dhis-web/dhis-web-commons-resources/src/main/webapp/dhis-web-commons/javascripts/dhis2/dhis2.angular.directives.js
+++ b/dhis-2/dhis-web/dhis-web-commons-resources/src/main/webapp/dhis-web-commons/javascripts/dhis2/dhis2.angular.directives.js
@@ -765,6 +765,7 @@ var d2Directives = angular.module('d2Directives', [])
                 var field = null;                               
                 
                 if ( ( key === 9 && event.shiftKey ) || key === 38 || key === 37 ) {//get previous input field
+                    console.log('event handled');
                                         
                 	event.preventDefault(); 
                     event.stopPropagation();
@@ -782,6 +783,10 @@ var d2Directives = angular.module('d2Directives', [])
                     
                     if( field ){                    
                         field.focus();
+                        var tempType=field[0].type;//need to change type temporarly to text because HTML5 doesn't allow setSelectionRange on number and some other inputs.
+                        field[0].type="text";
+                        field[0].setSelectionRange(0,field[0].value.length);
+                        field[0].type=tempType;
                     }
                 }                
                 else if( ( key === 9 && !event.shiftKey ) || key === 13 || key === 39 || key === 40 ){//get next input field
@@ -802,6 +807,10 @@ var d2Directives = angular.module('d2Directives', [])
                     
                     if( field ){                    
                         field.focus();
+                        var tempType=field[0].type;//need to change type temporarly to text because HTML5 doesn't allow setSelectionRange on number and some other inputs.
+                        field[0].type="text";
+                        field[0].setSelectionRange(0,field[0].value.length);
+                        field[0].type=tempType;
                     }                   
                 }
             });


### PR DESCRIPTION
The auto select partially works. Partially because the directive isn't fully implemented yet. 
And also contains making greyed fields invisible for the data-entry-app so that users shouldn't see them at all.